### PR TITLE
Fix validator tests and CLI wrappers

### DIFF
--- a/cli/qless_solver/dice.py
+++ b/cli/qless_solver/dice.py
@@ -8,7 +8,12 @@ to manipulate them.
 import random
 from typing import Dict, List, Optional, Tuple
 
-from pydantic import BaseModel, Field, field_validator
+try:  # Support both Pydantic v1 and v2
+    from pydantic import BaseModel, Field, field_validator
+    PYDANTIC_V2 = True
+except ImportError:  # pragma: no cover - fallback for older Pydantic
+    from pydantic import BaseModel, Field, validator as field_validator
+    PYDANTIC_V2 = False
 
 # The actual letter distribution on the Q-Less dice, sourced from BoardGameGeek
 # Each list represents one die with its six sides
@@ -70,7 +75,11 @@ class DiceSet(BaseModel):
         default_factory=list, description="The result of the last roll"
     )
 
-    model_config = {"arbitrary_types_allowed": True}
+    if PYDANTIC_V2:
+        model_config = {"arbitrary_types_allowed": True}
+    else:  # pragma: no cover - pydantic v1 style config
+        class Config:
+            arbitrary_types_allowed = True
 
     @classmethod
     def from_config(cls, dice_config: Optional[List[List[str]]] = None) -> "DiceSet":

--- a/cli/qless_solver/solver.py
+++ b/cli/qless_solver/solver.py
@@ -229,7 +229,7 @@ def validate_qless_arrangement(
                     # Validate word length
                     if len(word_str) < min_word_length:
                         current_errors.append(
-                            f"Word '{word_str}' (length {len(word_str)}) found {location_desc} is shorter than minimum word length {min_word_length}."
+                            f"Word '{word_str}' is shorter than min_word_length"
                         )
                     # Validate word against dictionary (only if long enough)
                     # Use min_length=1 for dictionary check, as the puzzle's min_word_length is already checked.

--- a/qless_solver/__init__.py
+++ b/qless_solver/__init__.py
@@ -1,0 +1,5 @@
+import importlib
+
+_impl = importlib.import_module('cli.qless_solver')
+__all__ = getattr(_impl, '__all__', [])
+__version__ = getattr(_impl, '__version__', '0.0.0')

--- a/qless_solver/cli.py
+++ b/qless_solver/cli.py
@@ -1,0 +1,6 @@
+from cli.qless_solver.cli import *  # type: ignore
+
+if __name__ == "__main__":  # pragma: no cover - thin wrapper
+    import sys
+
+    sys.exit(main())

--- a/qless_solver/dice.py
+++ b/qless_solver/dice.py
@@ -1,0 +1,1 @@
+from cli.qless_solver.dice import *

--- a/qless_solver/dictionary.py
+++ b/qless_solver/dictionary.py
@@ -1,0 +1,1 @@
+from cli.qless_solver.dictionary import *

--- a/qless_solver/generator.py
+++ b/qless_solver/generator.py
@@ -1,0 +1,1 @@
+from cli.qless_solver.generator import *

--- a/qless_solver/solver.py
+++ b/qless_solver/solver.py
@@ -1,0 +1,1 @@
+from cli.qless_solver.solver import *

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent
+# parent of tests directory
+ROOT = ROOT_DIR.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- add compatibility layer for Pydantic v1 in `dice.py`
- simplify error messages in `solver.py`
- expose package in new `qless_solver` wrappers for test imports
- run CLI when executed as module
- ensure tests can import project via `conftest`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68449257753483209fc974d3fa69bcf4