### PR TITLE
Fix docstring for index handler

### DIFF
--- a/web/main.py
+++ b/web/main.py
@@ -34,7 +34,7 @@ class SolveRequestBody(BaseModel):
 
 @app.get("/", response_class=HTMLResponse)
 async def read_index(request: Request):
-    """Serves the main HTML page.".""
+    """Serves the main HTML page."""
     return templates.TemplateResponse("index.html", {"request": request})
 
 # This is the endpoint HTMX will call. It needs to return an HTML snippet.


### PR DESCRIPTION
## Summary
- correct docstring for `read_index`

## Testing
- `python -m uvicorn web.main:app --reload` *(fails: jinja2 missing)*
- `pytest tests/e2e/test_web_api.py -q` *(fails: httpx missing)*

------
https://chatgpt.com/codex/tasks/task_e_6844934e6310832097b75421e331d05e