### PR TITLE
Implement Dictionary class and fix grid hashability

### DIFF
--- a/cli/qless_solver/dictionary.py
+++ b/cli/qless_solver/dictionary.py
@@ -158,3 +158,18 @@ def add_custom_words(words: Set[str]) -> None:
     dictionary = load_dictionary()
     for word in words:
         dictionary.add(word.lower())
+
+
+class Dictionary:
+    """Dictionary wrapper that loads and validates words."""
+
+    def __init__(self, path: Optional[Path] = None) -> None:
+        self.words: Set[str] = load_dictionary(path)
+
+    def is_valid_word(self, word: str) -> bool:
+        """Return True if ``word`` exists in this dictionary."""
+        return word.lower() in self.words
+
+    def load_dictionary(self, path: Path) -> None:
+        """Reload the dictionary from ``path``."""
+        self.words = load_dictionary(path)

--- a/cli/qless_solver/grid_solver.py
+++ b/cli/qless_solver/grid_solver.py
@@ -10,6 +10,9 @@ class GridPosition(BaseModel):
     y: int
     direction: str = "across"  # "across" or "down"
 
+    def __hash__(self) -> int:  # pragma: no cover - simple tuple hash
+        return hash((self.x, self.y, self.direction))
+
 class PlacedWord(BaseModel):
     word: str
     position: GridPosition


### PR DESCRIPTION
## Summary
- add a Dictionary class wrapping the existing dictionary helpers
- support hashing for `GridPosition`
- refactor grid solver to use these structures

## Testing
- `pytest tests/unit/test_grid_solver.py -q`
- `pytest tests/unit/test_dictionary.py -q`
- `pytest tests/unit/test_solver.py -q`
- `pytest tests/unit/test_generator.py -q` *(fails: ImportError: cannot import name 'field_validator' from 'pydantic')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684493edb1248320ac2fe7bebdbf41ef