### PR TITLE
Update imports to use package paths

### DIFF
--- a/cli/qless_solver/grid_solver.py
+++ b/cli/qless_solver/grid_solver.py
@@ -3,7 +3,7 @@ from typing import List, Dict, Tuple, Set
 from collections import Counter
 
 # Ensure this import path is correct based on your project structure
-from cli.qless_solver.dictionary import Dictionary
+from qless_solver.dictionary import Dictionary
 
 class GridPosition(BaseModel):
     x: int

--- a/web/main.py
+++ b/web/main.py
@@ -6,14 +6,15 @@ from typing import List, Dict # Added Dict
 import sys
 import os
 
-# Add the project root to the Python path
+# Add the cli directory to the Python path so qless_solver package is importable
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-if project_root not in sys.path:
-    sys.path.insert(0, project_root)
+cli_path = os.path.join(project_root, 'cli')
+if cli_path not in sys.path:
+    sys.path.insert(0, cli_path)
 
 try:
-    from cli.qless_solver.grid_solver import solve_qless_grid, GridSolution, Grid # Added Grid
-    from cli.qless_solver.dictionary import Dictionary # To handle potential init errors
+    from qless_solver.grid_solver import solve_qless_grid, GridSolution, Grid
+    from qless_solver.dictionary import Dictionary
 except ImportError as e:
     print(f"Error importing solver modules: {e}")
     # Handle as appropriate, e.g. by disabling features or raising an error at startup


### PR DESCRIPTION
## Summary
- adjust web server imports to use `qless_solver` package
- update solver module imports
- ensure FastAPI app adds `cli` directory to `sys.path`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684493ee44f88320901c231d4e0472f4