### PR TITLE
Add nixpacks config for Railway

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,9 @@
+[phases.setup]
+working_dir = "/app"
+nixPkgs = ["python312"]
+
+[phases.install]
+cmds = ["python -m pip install -e ."]
+
+[start]
+cmd = "python -m uvicorn web.main:app --host 0.0.0.0 --port $PORT"


### PR DESCRIPTION
## Summary
- add nixpacks.toml so Railway's Nixpacks build installs from the repo root
- run pip install using Python instead of relying on `pip` in PATH

## Testing
- `python3.12 -m venv venv && source venv/bin/activate && python -m pip install -e .[dev]`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844ddba41748320a7e9229186750e1c