### PR TITLE
Fix Nixpacks build path

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,8 @@
+[phases.setup]
+nixPkgs = ["python312"]
+
+[phases.build]
+cmds = ["python -m pip install -e ."]
+
+[start]
+cmd = "python -m uvicorn web.main:app --host 0.0.0.0 --port $PORT"


### PR DESCRIPTION
## Summary
- adjust Nixpacks config so `pip install -e .` runs during the build phase
- remove custom working directory entry

## Testing
- `python3.12 -m venv venv && source venv/bin/activate && python -m pip install -e .[dev]`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844ddba41748320a7e9229186750e1c