### PR TITLE
Add Dockerfile for running web portion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+COPY . .
+
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir . \
+    && pip install --no-cache-dir python-multipart
+
+EXPOSE 8000
+CMD ["python", "-m", "uvicorn", "web.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- add Dockerfile to run the FastAPI web server

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844fc74d21883208792da1113ff9170