### PR TITLE
Improve UI for dice solver

### DIFF
--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -11,7 +11,7 @@
         .container { max-width: 800px; margin: auto; background: white; padding: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
         h1 { color: #333; }
         label { display: block; margin-bottom: 5px; }
-        input[type="text"], input[type="number"] {
+        input[type="text"] {
             width: calc(100% - 22px); padding: 10px; margin-bottom: 15px; border: 1px solid #ddd; border-radius: 4px;
         }
         button {
@@ -19,8 +19,23 @@
         }
         button:hover { background-color: #0056b3; }
         #results { margin-top: 20px; padding: 10px; border: 1px solid #eee; border-radius: 4px; background-color: #f9f9f9; }
+        .camera-wrapper { margin-bottom: 15px; }
+        .camera-input {
+            display: none;
+        }
+        .camera-label {
+            width: 100%;
+            height: 200px;
+            border: 2px dashed #ccc;
+            border-radius: 8px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            font-size: 72px;
+            color: #888;
+            cursor: pointer;
+        }
         .solution-grid { display: grid; gap: 2px; margin-bottom: 10px; border: 1px solid #ccc; padding: 5px; background-color: #e0e0e0; max-width: fit-content;}
-        .grid-row { display: flex; }
         .grid-cell {
             width: 30px; height: 30px; background-color: #fff; border: 1px solid #ccc;
             display: flex; justify-content: center; align-items: center; font-weight: bold; text-transform: uppercase;
@@ -39,13 +54,9 @@
               hx-swap="innerHTML"
               hx-indicator="#loading-indicator"
               enctype="multipart/form-data">
-            <div>
-                <label for="image">Take a photo of your dice:</label>
-                <input type="file" id="image" name="image" accept="image/*" capture="environment" required>
-            </div>
-            <div>
-                <label for="img_min_word_length">Minimum word length (optional):</label>
-                <input type="number" id="img_min_word_length" name="min_word_length" value="3" min="2">
+            <div class="camera-wrapper">
+                <label for="image" class="camera-label">&#128247;</label>
+                <input type="file" id="image" class="camera-input" name="image" accept="image/*" capture="environment" required>
             </div>
             <button type="submit">Capture &amp; Solve</button>
         </form>
@@ -58,11 +69,7 @@
               hx-indicator="#loading-indicator">
             <div>
                 <label for="letters">Enter your letters:</label>
-                <input type="text" id="letters" name="letters" value="abcdef" required>
-            </div>
-            <div>
-                <label for="min_word_length">Minimum word length (optional):</label>
-                <input type="number" id="min_word_length" name="min_word_length" value="3" min="2">
+                <input type="text" id="letters" name="letters" maxlength="12" minlength="12" placeholder="Enter 12 letters" required>
             </div>
             <button type="submit">Solve</button>
             <span id="loading-indicator" style="display:none;">Loading...</span>

--- a/web/templates/results_snippet.html
+++ b/web/templates/results_snippet.html
@@ -18,15 +18,14 @@
                 {% set min_y = solution.cells.keys()|map(attribute=1)|min %}
                 {% set max_y = solution.cells.keys()|map(attribute=1)|max %}
 
-                <div class="solution-grid">
+                {% set col_count = max_x - min_x + 1 %}
+                <div class="solution-grid" style="grid-template-columns: repeat({{ col_count }}, 30px);">
                     {% for r in range(min_y, max_y + 1) %}
-                        <div class="grid-row">
-                            {% for c in range(min_x, max_x + 1) %}
-                                <div class="grid-cell {% if not solution.cells.get((c, r)) %}empty{% endif %}">
-                                    {{ solution.cells.get((c, r), '') }}
-                                </div>
-                            {% endfor %}
-                        </div>
+                        {% for c in range(min_x, max_x + 1) %}
+                            <div class="grid-cell {% if not solution.cells.get((c, r)) %}empty{% endif %}">
+                                {{ solution.cells.get((c, r), '') }}
+                            </div>
+                        {% endfor %}
                     {% endfor %}
                 </div>
             {% else %}


### PR DESCRIPTION
## Summary
- make camera input big and unobtrusive
- simplify forms by removing word length field and fixing 12-letter entry
- improve solution grid rendering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684508de2e10832093ffeea66ab185ea