### PR TITLE
Add default grid navigation

### DIFF
--- a/cli/qless_solver/image_detection.py
+++ b/cli/qless_solver/image_detection.py
@@ -1,7 +1,5 @@
 """Image-based letter detection utilities."""
 
-from typing import Iterable
-
 
 def detect_letters(image_bytes: bytes) -> str:
     """Stub to detect letters from an uploaded image.

--- a/tests/e2e/test_ui_default_grid.py
+++ b/tests/e2e/test_ui_default_grid.py
@@ -1,0 +1,75 @@
+import os
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Ensure the web app can be imported
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+try:
+    from web.main import app
+except Exception:
+    app = None
+
+GRID_CASES = {
+    "test_grid_1.jpg": [
+        ".f...",
+        "kohl.",
+        ".b.i.",
+        "...p.",
+        ".him.",
+        "...d.",
+    ],
+    "test_grid_2.jpg": [
+        ".....w",
+        ".....r",
+        ".l...a",
+        "pantry",
+        ".m....",
+        ".b....",
+    ],
+    "test_grid_3.jpg": [
+        "....s.",
+        "....h.",
+        "....a.",
+        ".l..k.",
+        "mildew",
+        ".d....",
+    ],
+    "test_grid_4.jpg": [
+        ".p...",
+        ".r.n.",
+        "comet",
+        ".n.x.",
+        ".g.t.",
+    ],
+}
+
+
+@pytest.fixture(scope="module")
+def client():
+    if app is None:
+        pytest.skip("FastAPI app not available for testing.")
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.mark.xfail(reason="Default grid not shown on page load yet")
+def test_index_displays_default_grid(client: TestClient):
+    response = client.get("/")
+    assert response.status_code == 200
+    html = response.text
+    assert "solution-grid" in html
+    for row in GRID_CASES["test_grid_1.jpg"]:
+        assert row in html
+
+
+@pytest.mark.xfail(reason="Navigation arrows not implemented yet")
+def test_index_has_navigation_arrows(client: TestClient):
+    response = client.get("/")
+    html = response.text
+    assert 'id="prev-solution"' in html
+    assert 'id="next-solution"' in html

--- a/tests/e2e/test_web_api.py
+++ b/tests/e2e/test_web_api.py
@@ -4,9 +4,6 @@ from collections import Counter  # Import Counter for mock solution
 
 import pytest
 from fastapi.testclient import TestClient
-import sys
-import os
-from collections import Counter  # Import Counter for mock solution
 
 # Add project root to sys.path to allow importing web.main
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
@@ -179,13 +176,14 @@ def test_solve_htmx_error_handling(client: TestClient, monkeypatch):
 
 
 def test_solve_image_endpoint(client: TestClient, monkeypatch):
-    from qless_solver.grid_solver import (
-        GridSolution,
-        Grid,
-        PlacedWord,
-        GridPosition,
-    )
     from io import BytesIO
+
+    from qless_solver.grid_solver import (
+        Grid,
+        GridPosition,
+        GridSolution,
+        PlacedWord,
+    )
 
     mock_solution = GridSolution(
         grid=Grid(

--- a/tests/unit/test_image_detection.py
+++ b/tests/unit/test_image_detection.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import pytest
+from qless_solver.image_detection import detect_letters
+
+ROLL_CASES = {
+    "test_roll_1.jpg": "kobfldhimiph",
+    "test_roll_2.jpg": "blyatarpwnmr",
+    "test_roll_3.jpg": "adwilkhldmes",
+    "test_roll_4.jpg": "rmtoepngtnxc",
+}
+
+
+@pytest.mark.parametrize("filename,expected", ROLL_CASES.items())
+@pytest.mark.xfail(reason="Image letter detection not implemented yet")
+def test_detect_letters_from_roll_images(filename: str, expected: str) -> None:
+    image_path = Path("tests/images") / filename
+    with open(image_path, "rb") as f:
+        image_bytes = f.read()
+    result = detect_letters(image_bytes)
+    assert result == expected

--- a/web/main.py
+++ b/web/main.py
@@ -1,10 +1,45 @@
-from fastapi import FastAPI, HTTPException, Request, Form, UploadFile, File
+import os
+import sys
+from typing import List
+
+from fastapi import FastAPI, File, Form, HTTPException, Request, UploadFile
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
-from typing import List, Dict  # Added Dict
-import sys
-import os
+
+DEFAULT_GRIDS = [
+    [
+        ".f...",
+        "kohl.",
+        ".b.i.",
+        "...p.",
+        ".him.",
+        "...d.",
+    ],
+    [
+        ".....w",
+        ".....r",
+        ".l...a",
+        "pantry",
+        ".m....",
+        ".b....",
+    ],
+    [
+        "....s.",
+        "....h.",
+        "....a.",
+        ".l..k.",
+        "mildew",
+        ".d....",
+    ],
+    [
+        ".p...",
+        ".r.n.",
+        "comet",
+        ".n.x.",
+        ".g.t.",
+    ],
+]
 
 # Add the cli directory to the Python path so qless_solver package is importable
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -13,8 +48,7 @@ if cli_path not in sys.path:
     sys.path.insert(0, cli_path)
 
 try:
-    from qless_solver.grid_solver import solve_qless_grid, GridSolution, Grid
-    from qless_solver.dictionary import Dictionary
+    from qless_solver.grid_solver import Grid, GridSolution, solve_qless_grid
     from qless_solver.image_detection import detect_letters
 except ImportError as e:
     print(f"Error importing solver modules: {e}")
@@ -42,7 +76,9 @@ class SolveRequestBody(BaseModel):
 @app.get("/", response_class=HTMLResponse)
 async def read_index(request: Request):
     """Serves the main HTML page."""
-    return templates.TemplateResponse("index.html", {"request": request})
+    return templates.TemplateResponse(
+        "index.html", {"request": request, "default_grids": DEFAULT_GRIDS}
+    )
 
 
 # This is the endpoint HTMX will call. It needs to return an HTML snippet.

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -183,6 +183,24 @@
             <span id="loading-indicator" style="display:none;">Loading...</span>
         </form>
 
+        {% if default_grids %}
+        <div id="default-grid-wrapper" style="text-align: center; margin-top: 20px;">
+            <button id="prev-solution" aria-label="Previous solution">&lt;</button>
+            <div id="solution-grid" class="solution-grid" style="display:inline-block;">
+                {% for row in default_grids[0] %}
+                <div class="grid-row">
+                    {% for ch in row %}
+                    <div class="grid-cell {% if ch == '.' %}empty{% endif %}">
+                        {{ '' if ch == '.' else ch }}
+                    </div>
+                    {% endfor %}
+                </div>
+                {% endfor %}
+            </div>
+            <button id="next-solution" aria-label="Next solution">&gt;</button>
+        </div>
+        {% endif %}
+
         <div id="results-container">
             <!-- Results will be loaded here by HTMX -->
             <p>Enter letters and click "Solve" to see results.</p>
@@ -211,6 +229,38 @@
             localStorage.setItem('darkMode', enabled);
             setMode(enabled);
         });
+
+        {% if default_grids %}
+        const defaultGrids = {{ default_grids|tojson }};
+        let currentGridIndex = 0;
+
+        function renderGrid(idx) {
+            const grid = defaultGrids[idx];
+            const container = document.getElementById('solution-grid');
+            container.innerHTML = '';
+            grid.forEach(row => {
+                const rowDiv = document.createElement('div');
+                rowDiv.className = 'grid-row';
+                for (const ch of row) {
+                    const cell = document.createElement('div');
+                    cell.className = 'grid-cell' + (ch === '.' ? ' empty' : '');
+                    cell.textContent = ch === '.' ? '' : ch;
+                    rowDiv.appendChild(cell);
+                }
+                container.appendChild(rowDiv);
+            });
+        }
+
+        document.getElementById('prev-solution').addEventListener('click', () => {
+            currentGridIndex = (currentGridIndex - 1 + defaultGrids.length) % defaultGrids.length;
+            renderGrid(currentGridIndex);
+        });
+
+        document.getElementById('next-solution').addEventListener('click', () => {
+            currentGridIndex = (currentGridIndex + 1) % defaultGrids.length;
+            renderGrid(currentGridIndex);
+        });
+        {% endif %}
 
         // Optional: Client-side script to handle JSON encoding for the form
         // if hx-ext="json-enc" is not sufficient or for more complex scenarios.


### PR DESCRIPTION
## Summary
- show default solution grids with navigation arrows
- serve default grids via FastAPI
- let user cycle through default grids using JS

## Testing
- `pip install -e .[dev]`
- `ruff check --fix`
- `isort .`
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845a4dbf4cc832098e254bc646ead6e