### PR TITLE
Add image thresholding helper and script

### DIFF
--- a/cli/qless_solver/preprocess.py
+++ b/cli/qless_solver/preprocess.py
@@ -1,0 +1,33 @@
+"""Image pre-processing utilities for OCR."""
+
+from __future__ import annotations
+
+import cv2
+import numpy as np
+
+
+def apply_threshold(image: np.ndarray) -> np.ndarray:
+    """Convert image to a binary thresholded form.
+
+    Steps:
+    1. Convert to grayscale.
+    2. Apply a 5x5 Gaussian blur.
+    3. Apply adaptive Gaussian thresholding.
+
+    Args:
+        image: Input image as a NumPy array in BGR format.
+
+    Returns:
+        The thresholded binary image.
+    """
+    gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    blurred = cv2.GaussianBlur(gray, (5, 5), 0)
+    thresh = cv2.adaptiveThreshold(
+        blurred,
+        255,
+        cv2.ADAPTIVE_THRESH_GAUSSIAN_C,
+        cv2.THRESH_BINARY,
+        11,
+        2,
+    )
+    return thresh

--- a/scripts/generate_golden_file.py
+++ b/scripts/generate_golden_file.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Utility to generate a thresholded image for manual verification."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import cv2
+
+# Ensure the project root is on the path when running directly from the repo
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from cli.qless_solver.preprocess import apply_threshold
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate thresholded image")
+    parser.add_argument(
+        "--input",
+        required=True,
+        type=Path,
+        help="Path to the source image",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Path to save the processed image",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    image = cv2.imread(str(args.input))
+    if image is None:
+        raise FileNotFoundError(f"Unable to load image: {args.input}")
+
+    result = apply_threshold(image)
+    cv2.imwrite(str(args.output), result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `apply_threshold` image preprocessing utility
- provide `generate_golden_file.py` script for generating a candidate golden file
- refine script to use `Path` objects and prepend project root to `sys.path`

## Testing
- `pip install -e .[dev]` *(fails: Operation cancelled by user while downloading torch and other packages)*
- `pytest -q` *(fails: ModuleNotFoundError for httpx, field_validator, cv2)*

------
https://chatgpt.com/codex/tasks/task_e_6846ae7d7e5883208ce6b496c94133c4