### PR TITLE
Add dice contour detection and debug script

### DIFF
--- a/cli/qless_solver/finder.py
+++ b/cli/qless_solver/finder.py
@@ -1,0 +1,35 @@
+"""Contour finding utilities for dice detection."""
+
+from __future__ import annotations
+
+from typing import List
+
+import cv2
+import numpy as np
+
+
+def find_dice_contours(
+    binary_image: np.ndarray, *, min_area: int = 100, max_area: int = 5000
+) -> List[np.ndarray]:
+    """Find contours that likely correspond to dice in a binary image.
+
+    This uses ``cv2.findContours`` with ``cv2.RETR_EXTERNAL`` to obtain only
+    outer contours. Contours are then filtered by area to remove noise.
+
+    Args:
+        binary_image: Thresholded image from :func:`apply_threshold`.
+
+    Returns:
+        A list of contours passing the area filter.
+    """
+    contours, _ = cv2.findContours(
+        binary_image, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
+    )
+
+    filtered: List[np.ndarray] = []
+    for contour in contours:
+        area = cv2.contourArea(contour)
+        if min_area <= area <= max_area:
+            filtered.append(contour)
+
+    return filtered

--- a/scripts/debug_contours.py
+++ b/scripts/debug_contours.py
@@ -1,0 +1,49 @@
+"""Visualize detected dice contours for debugging."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import cv2
+
+# Ensure project root is on the path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from cli.qless_solver.finder import find_dice_contours
+from cli.qless_solver.preprocess import apply_threshold
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Debug dice contour detection")
+    parser.add_argument(
+        "--input",
+        required=True,
+        type=Path,
+        help="Path to the source image",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Path to save the annotated image",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    image = cv2.imread(str(args.input))
+    if image is None:
+        raise FileNotFoundError(f"Unable to load image: {args.input}")
+
+    binary = apply_threshold(image)
+    contours = find_dice_contours(binary)
+
+    cv2.drawContours(image, contours, -1, (0, 255, 0), 2)
+    cv2.imwrite(str(args.output), image)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add helper `find_dice_contours` for detecting dice contours in a binary image
- add `debug_contours.py` script for visual debugging of contour detection
- allow contour finder to configure area thresholds

## Testing
- `pre-commit run --files cli/qless_solver/finder.py scripts/debug_contours.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68470ec04eb483209767991c9f685cd0